### PR TITLE
Fix parameter passed to snmp_sess_perror()

### DIFF
--- a/sendtrap.c
+++ b/sendtrap.c
@@ -104,7 +104,7 @@ int sendtrap(struct opts opts, char *community,
 		  message);
     
     if (!snmp_send(ss, pdu)) {
-      snmp_sess_perror("Error: sendtrap/snmp_send", &ss );
+      snmp_sess_perror("Error: sendtrap/snmp_send", ss );
       return_stat++;
     }
     snmp_close(ss);


### PR DESCRIPTION
snmp_sess_perror expects " netsnmp_session * "
currently passing " netsnmp_session ** "

The prototype for snmp_sess_error() is
snmp_sess_perror (const char *prog_string, netsnmp_session *ss);